### PR TITLE
Add google tracker id env variable in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,7 @@ Now you can visit `localhost:4000` from your browser.
 ```
 # GitHub authentication token to make API requests
 GITHUB_API_KEY=
+
+# Google Analytics tracker ID
+GOOGLE_ANALYTICS_TRACKER_ID=
 ```


### PR DESCRIPTION
Add missing environment variable `GOOGLE_ANALYTICS_TRACKER_ID` in `README.md` since it was added in pull request #1 
