### PR TITLE
Add all environment variables in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Now you can visit `localhost:4000` from your browser.
 # GitHub authentication token to make API requests
 GITHUB_API_KEY=
 
+# Secret token
+SECRET_KEY_BASE=
+
 ## Mandatory environment variables for prod environment
 
 # Listening on this port
@@ -27,7 +30,4 @@ GOOGLE_ANALYTICS_TRACKER_ID=
 
 # Canonical URL settings
 CANONICAL_HOST=
-
-# Secret token
-SECRET_KEY_BASE=
 ```

--- a/config/config.exs
+++ b/config/config.exs
@@ -9,7 +9,7 @@ use Mix.Config
 config :phoenix, OpenMirego.Router,
   url: [host: "localhost"],
   http: [port: System.get_env("PORT")],
-  secret_key_base: "VudCNV+dUpp13UIIERCct4JORo1zRNmQxHa24VozIB+v7BXzcW2p8lcxWEahemqCZizYsmkbDHd5GdCLoQoLiw==",
+  secret_key_base: System.get_env("SECRET_KEY_BASE"),
   catch_errors: true,
   debug_errors: false,
   error_controller: OpenMirego.PageController

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -12,10 +12,8 @@ use Mix.Config
 # disk for the key and cert.
 
 config :phoenix, OpenMirego.Router,
-  http: [port: System.get_env("PORT")],
   ssl: false,
-  host: System.get_env("CANONICAL_HOST"),
-  secret_key_base: System.get_env("SECRET_KEY_BASE")
+  host: System.get_env("CANONICAL_HOST")
 
 config :logger,
   level: :info


### PR DESCRIPTION
As saying in pull request #2, the `README` now include all environment variables. Now when a user start this project and read the `README`, they will know exactly existing environment variables for all environments even if they are optional.
