### PR TITLE
Remove unused error handling code

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -11,8 +11,7 @@ config :phoenix, OpenMirego.Router,
   http: [port: System.get_env("PORT")],
   secret_key_base: "VudCNV+dUpp13UIIERCct4JORo1zRNmQxHa24VozIB+v7BXzcW2p8lcxWEahemqCZizYsmkbDHd5GdCLoQoLiw==",
   catch_errors: true,
-  debug_errors: false,
-  error_controller: OpenMirego.PageController
+  debug_errors: false
 
 config :github, OpenMirego.Router,
   api_key: System.get_env("GITHUB_API_KEY")

--- a/web/controllers/page_controller.ex
+++ b/web/controllers/page_controller.ex
@@ -18,12 +18,4 @@ defmodule OpenMirego.PageController do
       _ -> redirect(conn, to: page_path(:index))
     end
   end
-
-  def not_found(conn, _params) do
-    render conn, "not_found.html"
-  end
-
-  def error(conn, _params) do
-    render conn, "error.html"
-  end
 end


### PR DESCRIPTION
Until we end up with a clean way to handle errors, let’s remove this code. It does nothing.
