### PR TITLE
Prevent “M” menu from overlapping header text in medium-sized viewports

### DIFF
--- a/priv/static/css/style.css
+++ b/priv/static/css/style.css
@@ -315,9 +315,7 @@ footer a {
   .repo:nth-child(2n) {
     margin-right: 0 !important;
   }
-}
 
-@media only screen and (max-width: 480px) {
   .m {
     top: 0;
     right: 0;
@@ -336,7 +334,9 @@ footer a {
   .m > span {
     display: none;
   }
+}
 
+@media only screen and (max-width: 480px) {
   header {
     height: 140px;
   }


### PR DESCRIPTION
Let’s reduce the **M** to its smallest size when the _medium-sized viewport_ media query is triggered to prevent it from overlapping the header content.

### Before
![screen shot 2015-12-30 at 13 41 02](https://cloud.githubusercontent.com/assets/11348/12055471/9ae8eabe-aefb-11e5-8ea6-5557e9098e44.png)

### After
![screen shot 2015-12-30 at 13 41 11](https://cloud.githubusercontent.com/assets/11348/12055470/9ae1ea52-aefb-11e5-9d38-837f7f0fab3d.png)