### PR TITLE
Downgrade to Elixir 1.1.1 and Erlang 17.5

### DIFF
--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,4 +1,4 @@
-erlang_version=18.0
-elixir_version=1.2.0
+erlang_version=17.5
+elixir_version=1.1.1
 rebar_version=2.1.0
 always_build_deps=false

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule OpenMirego.Mixfile do
   def project do
     [app: :open_mirego,
      version: "0.0.1",
-     elixir: "~> 1.2.0",
+     elixir: "~> 1.1.0",
      elixirc_paths: ["lib", "web"],
      compilers: [:phoenix] ++ Mix.compilers,
      elixirc_paths: elixirc_paths(Mix.env),


### PR DESCRIPTION
Well… turns out that I should have deployed on Heroku before. We have this error on deploy.

```
remote: Compiling src/ibrowse_lib.erl failed:
remote: src/ibrowse_lib.erl:371: erlang:now/0: Deprecated BIF. See the "Time and Time Correction in Erlang" chapter of the ERTS User's Guide for more information.
```

Let’s revert for now.