### PR TITLE
Upgrade Elixir to 1.2.0 and Erlang to 18.2.1

### DIFF
--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,4 +1,4 @@
-erlang_version=17.5
-elixir_version=1.1.1
+erlang_version=18.2.1
+elixir_version=1.2.0
 rebar_version=2.1.0
 always_build_deps=false

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule OpenMirego.Mixfile do
   def project do
     [app: :open_mirego,
      version: "0.0.1",
-     elixir: "~> 1.1.0",
+     elixir: "~> 1.2.0",
      elixirc_paths: ["lib", "web"],
      compilers: [:phoenix] ++ Mix.compilers,
      elixirc_paths: elixirc_paths(Mix.env),
@@ -29,7 +29,7 @@ defmodule OpenMirego.Mixfile do
     [{:phoenix, "~> 1.0"},
      {:phoenix_html, "~> 2.0"},
      {:con_cache, "~> 0.8.1"},
-     {:ibrowse, github: "cmullaparthi/ibrowse", tag: "v4.1.1"},
+     {:ibrowse, github: "cmullaparthi/ibrowse", tag: "v4.1.2"},
      {:httpotion, "~> 0.2.0"},
      {:timex, "~> 0.19.0"},
      {:cowboy, "~> 1.0"}]

--- a/mix.lock
+++ b/mix.lock
@@ -5,7 +5,7 @@
   "exactor": {:hex, :exactor, "2.1.2"},
   "hackney": {:hex, :hackney, "1.3.2"},
   "httpotion": {:hex, :httpotion, "0.2.4"},
-  "ibrowse": {:git, "git://github.com/cmullaparthi/ibrowse.git", "d2e369ff42666c3574b8b7ec26f69027895c4d94", [tag: "v4.1.1"]},
+  "ibrowse": {:git, "https://github.com/cmullaparthi/ibrowse.git", "ea3305d21f37eced4fac290f64b068e56df7de80", [tag: "v4.1.2"]},
   "idna": {:hex, :idna, "1.0.2"},
   "phoenix": {:hex, :phoenix, "1.0.0"},
   "phoenix_html": {:hex, :phoenix_html, "2.1.2"},


### PR DESCRIPTION
OK, let’s upgrade to Elixir 1.2.0 for real now!

![](https://cloud.githubusercontent.com/assets/11348/12178530/f0eb6adc-b53f-11e5-8e4c-ca1ef333d34a.gif)