### PR TITLE
Add and use plug_canonical_host

### DIFF
--- a/lib/open_mirego/endpoint.ex
+++ b/lib/open_mirego/endpoint.ex
@@ -1,6 +1,9 @@
 defmodule OpenMirego.Endpoint do
   use Phoenix.Endpoint, otp_app: :open_mirego
 
+  # Always serve requests from a single canonical host
+  plug PlugCanonicalHost, canonical_host: Application.get_env(:open_mirego, OpenMirego.Endpoint)[:url][:host]
+
   # Serve at "/" the given assets from "priv/static" directory
   plug Plug.Static,
     at: "/", from: :open_mirego,

--- a/mix.exs
+++ b/mix.exs
@@ -32,6 +32,7 @@ defmodule OpenMirego.Mixfile do
      {:ibrowse, github: "cmullaparthi/ibrowse", tag: "v4.1.2"},
      {:httpotion, "~> 0.2.0"},
      {:timex, "~> 0.19.0"},
+     {:plug_canonical_host, "~> 0.2.0"},
      {:cowboy, "~> 1.0"}]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -10,6 +10,7 @@
   "phoenix": {:hex, :phoenix, "1.0.0"},
   "phoenix_html": {:hex, :phoenix_html, "2.1.2"},
   "plug": {:hex, :plug, "1.0.0"},
+  "plug_canonical_host": {:hex, :plug_canonical_host, "0.2.1"},
   "poison": {:hex, :poison, "1.5.0"},
   "ranch": {:hex, :ranch, "1.1.0"},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},


### PR DESCRIPTION
Yesterday I published [`plug_canonical_host`](https://hex.pm/packages/plug_canonical_host). Let’s use it now!