### PR TITLE
Add visual support for Swift projects

### DIFF
--- a/lib/repo/serializer.ex
+++ b/lib/repo/serializer.ex
@@ -53,14 +53,16 @@ defmodule OpenMirego.Repo.Serializer do
   defp parsed_language("JavaScript"),  do: "js"
   defp parsed_language("CSS"),         do: "css"
   defp parsed_language("Java"),        do: "java"
+  defp parsed_language("Swift"),       do: "swift"
   defp parsed_language(nil),           do: "none"
   defp parsed_language(lang),          do: lang
 
-  defp parsed_pretty_language("Objective-C"), do: "iOS"
+  defp parsed_pretty_language("Objective-C"), do: "Obj-C"
   defp parsed_pretty_language("Ruby"),        do: "Ruby"
   defp parsed_pretty_language("JavaScript"),  do: "JS"
   defp parsed_pretty_language("CSS"),         do: "CSS"
   defp parsed_pretty_language("Java"),        do: "Java"
+  defp parsed_pretty_language("Swift"),       do: "Swift"
   defp parsed_pretty_language(nil),           do: ""
   defp parsed_pretty_language(lang),          do: lang
 

--- a/priv/static/css/style.css
+++ b/priv/static/css/style.css
@@ -168,6 +168,14 @@ a {
   background-color: rgba(3, 93, 169, 0.8);
 }
 
+.repo--language-swift .repo-header-language {
+  background-color: rgba(255, 157, 43, 1);
+}
+
+.repo--language-swift:hover .repo-header-language {
+  background-color: rgba(255, 157, 43, 0.8);
+}
+
 .repo--language-none .repo-header-language {
   display: none;
 }


### PR DESCRIPTION
Now that we have public Swift projects, let’s identify them as such and not identify Objective-C ones as _iOS_ projects, since we show the language iself for every other languages.

![](https://cloud.githubusercontent.com/assets/11348/13649722/fdaff64a-e60c-11e5-8f86-ceb0829d2608.png)
