### PR TITLE
Add FORCE_SSL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ GOOGLE_ANALYTICS_TRACKER_ID=
 
 # Canonical URL settings
 CANONICAL_HOST=
+
+# Force HTTPS requests
+FORCE_SSL=
 ```
 
 ## License

--- a/config/config.exs
+++ b/config/config.exs
@@ -5,6 +5,12 @@
 # is restricted to this project.
 use Mix.Config
 
+defmodule Utilities do
+  def string_to_boolean("true"), do: true
+  def string_to_boolean("1"), do: true
+  def string_to_boolean(_), do: false
+end
+
 # Configures the endpoint
 config :open_mirego, OpenMirego.Endpoint,
   root: Path.expand("..", __DIR__),
@@ -21,6 +27,8 @@ config :open_mirego, OpenMirego.GoogleAnalytics,
 
 config :open_mirego, OpenMirego.Typekit,
   kit_id: System.get_env("TYPEKIT_KIT_ID")
+
+config :open_mirego, force_ssl: Utilities.string_to_boolean(System.get_env("FORCE_SSL"))
 
 # Configures Elixir's Logger
 config :logger, :console,

--- a/lib/open_mirego/endpoint.ex
+++ b/lib/open_mirego/endpoint.ex
@@ -4,6 +4,11 @@ defmodule OpenMirego.Endpoint do
   # Always serve requests from a single canonical host
   plug PlugCanonicalHost, canonical_host: get_in(Application.get_env(:open_mirego, OpenMirego.Endpoint), [:url, :host])
 
+  # Force SSL
+  if Application.get_env(:open_mirego, :force_ssl) do
+    plug Plug.SSL, rewrite_on: [:x_forwarded_proto]
+  end
+
   # Serve at "/" the given assets from "priv/static" directory
   plug Plug.Static,
     at: "/", from: :open_mirego,


### PR DESCRIPTION
If `FORCE_SSL` environment variable is present, force HTTPS requests.