### PR TITLE
Add GTM tracking ID

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -22,5 +22,12 @@ module.exports = {
         trackingId: process.env.GOOGLE_ANALYTICS_TRACKER_ID,
       },
     },
+    {
+      resolve: 'gatsby-plugin-google-tagmanager',
+      options: {
+        id: 'GTM-TW4FPB3',
+        includeInDevelopment: false,
+      },
+    },
   ],
 };

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -17,12 +17,6 @@ module.exports = {
     'gatsby-transformer-sharp',
     'gatsby-plugin-sharp',
     {
-      resolve: 'gatsby-plugin-google-analytics',
-      options: {
-        trackingId: process.env.GOOGLE_ANALYTICS_TRACKER_ID,
-      },
-    },
-    {
       resolve: 'gatsby-plugin-google-tagmanager',
       options: {
         id: 'GTM-TW4FPB3',

--- a/package-lock.json
+++ b/package-lock.json
@@ -8810,15 +8810,6 @@
         "@emotion/babel-preset-css-prop": "^10.0.27"
       }
     },
-    "gatsby-plugin-google-analytics": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-2.8.0.tgz",
-      "integrity": "sha512-gPJU80Pj3yK9eUOLJrX3vRXYMXzWZW9nuvnExdpqUX1fnCDMmFSnRtwWkb3CFqXm9SfmfKl2V/A8KqKAttXcXg==",
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "minimatch": "3.0.4"
-      }
-    },
     "gatsby-plugin-google-tagmanager": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-google-tagmanager/-/gatsby-plugin-google-tagmanager-2.9.0.tgz",
@@ -17554,6 +17545,18 @@
         "lodash": "^4.17.15",
         "postcss": "^7.0.31",
         "postcss-sorting": "^5.0.1"
+      }
+    },
+    "stylelint-processor-styled-components": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/stylelint-processor-styled-components/-/stylelint-processor-styled-components-1.10.0.tgz",
+      "integrity": "sha512-g4HpN9rm0JD0LoHuIOcd/FIjTZCJ0ErQ+dC3VTxp+dSvnkV+MklKCCmCQEdz5K5WxF4vPuzfVgdbSDuPYGZhoA==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.8.3",
+        "@babel/traverse": "^7.8.3",
+        "micromatch": "^4.0.2",
+        "postcss": "^7.0.26"
       }
     },
     "sudo-prompt": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8819,6 +8819,14 @@
         "minimatch": "3.0.4"
       }
     },
+    "gatsby-plugin-google-tagmanager": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-tagmanager/-/gatsby-plugin-google-tagmanager-2.9.0.tgz",
+      "integrity": "sha512-Te4SWBKLFjppYf0sIOkdlRerq25relPL8v/8wN/PZwDHaxzSZ3PNEO9n9QjPr+MeztljEZVdWi6LKniyIT8T9Q==",
+      "requires": {
+        "@babel/runtime": "^7.12.5"
+      }
+    },
     "gatsby-plugin-page-creator": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.7.1.tgz",
@@ -17546,17 +17554,6 @@
         "lodash": "^4.17.15",
         "postcss": "^7.0.31",
         "postcss-sorting": "^5.0.1"
-      }
-    },
-    "stylelint-processor-styled-components": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/stylelint-processor-styled-components/-/stylelint-processor-styled-components-1.5.2.tgz",
-      "integrity": "sha512-sjOU/GtTQMR1McdntJWo6Za1wbdl5YuxQwWm5l2Nz6ELYoVI9WJTZbU9DQcvkOGjW3+HEk4ZKBytqFrMJPIx9Q==",
-      "dev": true,
-      "requires": {
-        "@babel/parser": "^7.0.0",
-        "@babel/traverse": "^7.0.0",
-        "postcss": "^7.0.0"
       }
     },
     "sudo-prompt": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "gatsby-image": "^2.0.35",
     "gatsby-plugin-emotion": "^4.5.0",
     "gatsby-plugin-google-analytics": "^2.8.0",
+    "gatsby-plugin-google-tagmanager": "^2.9.0",
     "gatsby-plugin-react-helmet": "^3.7.0",
     "gatsby-plugin-sharp": "^2.11.1",
     "gatsby-source-filesystem": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "gatsby": "^2.29.1",
     "gatsby-image": "^2.0.35",
     "gatsby-plugin-emotion": "^4.5.0",
-    "gatsby-plugin-google-analytics": "^2.8.0",
     "gatsby-plugin-google-tagmanager": "^2.9.0",
     "gatsby-plugin-react-helmet": "^3.7.0",
     "gatsby-plugin-sharp": "^2.11.1",


### PR DESCRIPTION
## 📖 Description

Let’s add the `gatsby-plugin-google-tagmanager` plugin to track some page views 🤓📈

Let’s also remove the `gatsby-plugin-google-analytics` plugin since we won’t need it anymore.

## 🦀 Dispatch

- `#dispatch/react`