### PR TITLE
Use environment variable for GTM ID

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -17,6 +17,7 @@ jobs:
       - run: make build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GOOGLE_TAG_MANAGER_ID: GTM-TW4FPB3
       - uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -19,7 +19,7 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-google-tagmanager',
       options: {
-        id: 'GTM-TW4FPB3',
+        id: process.env.GOOGLE_TAG_MANAGER_ID,
         includeInDevelopment: false,
       },
     },


### PR DESCRIPTION
## 📖 Description

As [suggested](https://github.com/mirego/mirego-open-web/pull/41#discussion_r556070933) by @gcauchon in my last pull request.

It’s cleaner to use an environment variable instead of bundling up the ID directly in the code.

## 🦀 Dispatch

- `#dispatch/react`