### PR TITLE
Remove physical CNAME file

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -22,3 +22,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
+          cname: open.mirego.com

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,0 @@
-open.mirego.com


### PR DESCRIPTION
## 📖 Description

We don’t need to maintain a _real_ `CNAME` file — the `peaceiris/actions-gh-pages` action can take care of it for us!

## 🦀 Dispatch

_None_
