### PR TITLE
Show “smoother to the eyes” images in dark mode

### DIFF
--- a/src/components/ExternalProject.js
+++ b/src/components/ExternalProject.js
@@ -19,6 +19,8 @@ const ImageWrapper = styled.div`
 
 const Image = styled.img`
   height: 50px;
+  opacity: 0.75;
+  filter: saturate(0.75);
 `;
 
 export default ({url, logo, name}) => (

--- a/src/components/Project.js
+++ b/src/components/Project.js
@@ -59,6 +59,8 @@ const Image = styled.img`
   height: 60px;
   animation: 0.5s zoom-in;
   transition: transform 0.1s ease-in;
+  opacity: 0.75;
+  filter: saturate(0.75);
 
   a:hover & {
     transform: scale3d(1.075, 1.075, 1.075);


### PR DESCRIPTION
## 📖 Description

Something that has been bothered me for a while.

## 🎉 Result

<table>
<tr>
	<th>Before
	<th>After
<tr>
	<td><img width="1030" alt="" src="https://user-images.githubusercontent.com/11348/196567283-be489f41-bc57-4e7d-95d6-ca834029d310.png">
	<td><img width="1038" alt="" src="https://user-images.githubusercontent.com/11348/196567294-53b2bfe8-f95a-464d-9033-71fec995684f.png">
</table>

## 🦀 Dispatch

- `#dispatch/react`
