### PR TITLE
Add error handling when using erroneous GitHub token

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -8,6 +8,11 @@ const getRepository = async (slug) => {
     },
   });
 
+  if (response.status !== 200) {
+    console.error(`Error fetching repository mirego/${slug}: ${response.status} ${response.statusText}`);
+    return process.exit();
+  }
+
   return await response.json();
 };
 


### PR DESCRIPTION
## 📖 Description

Le code actuel n’était pas très résilient si on utilisait un mauvais token pour communiquer avec l’API de GitHub.

Ça buildait le site dans un état erroné, ça fuckait le data, etc.

Maintenant c’est _impossible_ de builder avec un mauvais token.

## 🦀 Dispatch

- `#dispatch/react`
